### PR TITLE
refactor(runner): move constructor params from RunTests to NewRunner

### DIFF
--- a/internal/testexecution/processor/processor.go
+++ b/internal/testexecution/processor/processor.go
@@ -34,15 +34,15 @@ import (
 
 // runnerInterface allows dependency injection for test runners (for production and testing).
 type runnerInterface interface {
-	RunTests(testSuiteSpec *api.TestSuiteSpec, testSuiteFile string) error
+	RunTests() error
 }
 
 // Mockable functions
 //
 //nolint:gochecknoglobals // Global variables for dependency injection in tests
 var (
-	newRunnerFunc = func(options *testexecutionUtils.Options) runnerInterface {
-		return runner.NewRunner(options)
+	newRunnerFunc = func(options *testexecutionUtils.Options, testSuiteFile string, testSuiteSpec *api.TestSuiteSpec) runnerInterface {
+		return runner.NewRunner(options, testSuiteFile, testSuiteSpec)
 	}
 )
 
@@ -189,9 +189,9 @@ func processTestSuiteFile(fs afero.Fs, testSuiteFile string, options *testexecut
 		return reportTestSuiteError(testSuiteFile, err, "invalid testsuite file")
 	}
 
-	testRunner := newRunnerFunc(options)
+	testRunner := newRunnerFunc(options, testSuiteFile, testSuiteSpec)
 
-	fileErr := testRunner.RunTests(testSuiteSpec, testSuiteFile)
+	fileErr := testRunner.RunTests()
 	if fileErr != nil {
 		errMsg := fileErr.Error()
 		if !strings.Contains(errMsg, "tests failed in testsuite") {

--- a/internal/testexecution/runner/patches_test.go
+++ b/internal/testexecution/runner/patches_test.go
@@ -53,7 +53,7 @@ spec:
 	options := &testexecutionUtils.Options{
 		Debug: false,
 	}
-	runner := NewRunner(options)
+	runner := NewRunner(options, testSuiteFile, &api.TestSuiteSpec{Tests: []api.TestCase{}})
 	runner.fs = fs // Use in-memory filesystem
 
 	tests := []struct {


### PR DESCRIPTION
Refactor the Runner API to pass testSuiteFile and testSuiteSpec as parameters to NewRunner instead of RunTests. This simplifies the API by making the constructor responsible for setting up the runner with all required configuration.

This is a pure refactoring with no behavior change.