### PR TITLE
fix(runner): set working directory for hooks to testsuite file location

### DIFF
--- a/internal/testexecution/runner/runner.go
+++ b/internal/testexecution/runner/runner.go
@@ -40,10 +40,11 @@ import (
 type Runner struct {
 	*testexecutionUtils.Options
 
-	fs            afero.Fs
-	testSuiteSpec *api.TestSuiteSpec
-	testSuiteFile string
-	output        io.Writer
+	fs               afero.Fs
+	testSuiteSpec    *api.TestSuiteSpec
+	testSuiteFile    string
+	testSuiteFileDir string
+	output           io.Writer
 	// Directory paths
 	inputsDir             string
 	outputsDir            string
@@ -74,18 +75,22 @@ type templateContext struct {
 
 // NewRunner creates a new test runner.
 func NewRunner(options *testexecutionUtils.Options, testSuiteFile string, testSuiteSpec *api.TestSuiteSpec) *Runner {
+	testSuiteFileDir := filepath.Dir(testSuiteFile)
+
 	return &Runner{
-		fs:            afero.NewOsFs(),
-		output:        os.Stdout, // Default output to stdout
-		Options:       options,
-		testSuiteFile: testSuiteFile,
-		testSuiteSpec: testSuiteSpec,
+		fs:               afero.NewOsFs(),
+		output:           os.Stdout, // Default output to stdout
+		Options:          options,
+		testSuiteFile:    testSuiteFile,
+		testSuiteFileDir: testSuiteFileDir,
+		testSuiteSpec:    testSuiteSpec,
 		// Initialize mockable function fields with default implementations
 		runTestCaseFunc:                   nil, // will set default below
 		expandPathRelativeToTestSuiteFile: testexecutionUtils.ExpandPathRelativeToTestSuiteFile,
 		verifyPathExists:                  utils.VerifyPathExists,
 		runCommand: func(name string, args ...string) ([]byte, []byte, error) {
 			cmd := exec.Command(name, args...)
+			cmd.Dir = testSuiteFileDir
 
 			var stdout, stderr bytes.Buffer
 


### PR DESCRIPTION
### Description

Hooks were executing with the current working directory set to wherever xprin was invoked from, rather than the directory containing the testsuite file. This caused issues when hooks tried to access files using relative paths, as those paths were resolved relative to the wrong directory.

Additionally, all commands executed through runCommand (not just hooks) were not setting a working directory, which while harmless in most cases, is inconsistent with how xprin handles relative paths for inputs (which are resolved relative to the testsuite file).

The fix sets cmd.Dir in the runCommand wrapper (which wraps exec.Command) to the testsuite file's directory. This ensures all commands, including hooks, execute with the correct working directory, making relative paths in hooks work as expected.

Fixes #2

### Reproducer
Create a testsuite file with a pre-test hook that runs pwd:

```bash
examples/mytests/reproducer/reproducer_cwd_bug_xprin.yaml
```

```yaml
tests:
- name: "Reproducer for #2: Check working directory in pre-test hook"
  inputs:
    xr: ../../base/xr.yaml
    composition: ../../base/composition.yaml
    functions: ../../base/functions.yaml
  hooks:
    pre-test:
    - name: "Check current working directory with pwd"
      run: pwd
```

#### Outputs

<details> <summary> before the fix </summary>

```
➜ git branch --show-current
main

➜ go run ./cmd/xprin test examples/mytests/reproducer/reproducer_cwd_bug_xprin.yaml -v --show-hooks
=== RUN   Reproducer for #2: Check working directory in pre-test hook
--- PASS: Reproducer for #2: Check working directory in pre-test hook (0.93s)
    pre-test hooks results:
        - Check current working directory with pwd
            /Users/tampakrap/Repos/github.com/crossplane-contrib/xprin
PASS
ok	examples/mytests/reproducer/reproducer_cwd_bug_xprin.yaml	0.930s

➜ cd examples
➜ go run ../cmd/xprin test mytests/reproducer/reproducer_cwd_bug_xprin.yaml -v --show-hooks
=== RUN   Reproducer for #2: Check working directory in pre-test hook
--- PASS: Reproducer for #2: Check working directory in pre-test hook (0.77s)
    pre-test hooks results:
        - Check current working directory with pwd
            /Users/tampakrap/Repos/github.com/crossplane-contrib/xprin/examples
PASS
ok	mytests/reproducer/reproducer_cwd_bug_xprin.yaml	0.770s
```
</details>

`pwd` outputs the directory from which xprin was invoked

<details> <summary> after the fix </summary>

```
➜ git branch --show-current
fix_runcommand_set_cwd

➜ go run ./cmd/xprin test examples/mytests/reproducer/reproducer_cwd_bug_xprin.yaml -v --show-hooks
=== RUN   Reproducer for #2: Check working directory in pre-test hook
--- PASS: Reproducer for #2: Check working directory in pre-test hook (0.76s)
    pre-test hooks results:
        - Check current working directory with pwd
            /Users/tampakrap/Repos/github.com/crossplane-contrib/xprin/examples/mytests/reproducer
PASS
ok	examples/mytests/reproducer/reproducer_cwd_bug_xprin.yaml	0.763s

➜ cd examples
➜ go run ../cmd/xprin test mytests/reproducer/reproducer_cwd_bug_xprin.yaml -v --show-hooks
=== RUN   Reproducer for #2: Check working directory in pre-test hook
--- PASS: Reproducer for #2: Check working directory in pre-test hook (0.89s)
    pre-test hooks results:
        - Check current working directory with pwd
            /Users/tampakrap/Repos/github.com/crossplane-contrib/xprin/examples/mytests/reproducer
PASS
ok	mytests/reproducer/reproducer_cwd_bug_xprin.yaml	0.897s
```
</details>

`pwd` outputs the directory containing the testsuite file