### PR TITLE
refactor(assertions)!: restructure assertions to use xprin key

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -15,6 +15,20 @@ Assertions are executed after Crossplane validation (if CRDs are provided) or af
 
 For information about how assertions work internally, see [How It Works](how-it-works.md#assertions-execution).
 
+## Structure
+
+Assertions are organized by execution engine. Currently, `xprin` assertions are supported (in-process assertions). The structure allows for future extensibility to support other assertion engines e.g. `chainsaw`.
+
+```yaml
+assertions:
+  xprin:
+    - name: "my-assertion"
+      type: "Count"
+      value: 3
+```
+
+All assertions must be placed under the `xprin` key within the `assertions` section.
+
 ## Field Reference
 
 | Field | Required | Type | Description |
@@ -42,9 +56,10 @@ Validates the total number of rendered resources.
 **Example:**
 ```yaml
 assertions:
-  - name: "renders-three-resources"
-    type: "Count"
-    value: 3
+  xprin:
+    - name: "renders-three-resources"
+      type: "Count"
+      value: 3
 ```
 
 **Use Case:** Ensure a composition renders exactly the expected number of resources.
@@ -63,12 +78,13 @@ Validates that a specific resource exists in the rendered output.
 **Example:**
 ```yaml
 assertions:
-  - name: "deployment-exists"
-    type: "Exists"
-    resource: "Deployment/my-app"
-  - name: "service-exists"
-    type: "Exists"
-    resource: "Service/my-app"
+  xprin:
+    - name: "deployment-exists"
+      type: "Exists"
+      resource: "Deployment/my-app"
+    - name: "service-exists"
+      type: "Exists"
+      resource: "Service/my-app"
 ```
 
 **Use Case:** Verify that specific resources are created by the composition.
@@ -87,12 +103,13 @@ Validates that a resource does not exist in the rendered output.
 **Example:**
 ```yaml
 assertions:
-  - name: "no-old-deployment"
-    type: "NotExists"
-    resource: "Deployment/old-app"
-  - name: "no-pods"
-    type: "NotExists"
-    resource: "Pod"
+  xprin:
+    - name: "no-old-deployment"
+      type: "NotExists"
+      resource: "Deployment/old-app"
+    - name: "no-pods"
+      type: "NotExists"
+      resource: "Pod"
 ```
 
 **Use Case:** Ensure deprecated resources are not created, or verify that certain resource types are excluded.
@@ -121,36 +138,37 @@ Validates the type of a field in a resource.
 **Example:**
 ```yaml
 assertions:
-  - name: "replicas-is-number"
-    type: "FieldType"
-    resource: "Deployment/my-app"
-    field: "spec.replicas"
-    value: "number"
-  - name: "name-is-string"
-    type: "FieldType"
-    resource: "Deployment/my-app"
-    field: "metadata.name"
-    value: "string"
-  - name: "labels-is-object"
-    type: "FieldType"
-    resource: "Deployment/my-app"
-    field: "metadata.labels"
-    value: "object"
-  - name: "ports-is-array"
-    type: "FieldType"
-    resource: "Service/my-app"
-    field: "spec.ports"
-    value: "array"
-  - name: "enabled-is-boolean"
-    type: "FieldType"
-    resource: "Deployment/my-app"
-    field: "spec.enabled"
-    value: "boolean"
-  - name: "optional-field-is-null"
-    type: "FieldType"
-    resource: "Deployment/my-app"
-    field: "spec.optionalField"
-    value: "null"
+  xprin:
+    - name: "replicas-is-number"
+      type: "FieldType"
+      resource: "Deployment/my-app"
+      field: "spec.replicas"
+      value: "number"
+    - name: "name-is-string"
+      type: "FieldType"
+      resource: "Deployment/my-app"
+      field: "metadata.name"
+      value: "string"
+    - name: "labels-is-object"
+      type: "FieldType"
+      resource: "Deployment/my-app"
+      field: "metadata.labels"
+      value: "object"
+    - name: "ports-is-array"
+      type: "FieldType"
+      resource: "Service/my-app"
+      field: "spec.ports"
+      value: "array"
+    - name: "enabled-is-boolean"
+      type: "FieldType"
+      resource: "Deployment/my-app"
+      field: "spec.enabled"
+      value: "boolean"
+    - name: "optional-field-is-null"
+      type: "FieldType"
+      resource: "Deployment/my-app"
+      field: "spec.optionalField"
+      value: "null"
 ```
 
 **Use Case:** Validate that fields have the correct data types, ensuring type safety in rendered manifests.
@@ -170,14 +188,15 @@ Validates that a field exists at a given path in a resource.
 **Example:**
 ```yaml
 assertions:
-  - name: "has-replicas-field"
-    type: "FieldExists"
-    resource: "Deployment/my-app"
-    field: "spec.replicas"
-  - name: "has-selector"
-    type: "FieldExists"
-    resource: "Service/my-app"
-    field: "spec.selector"
+  xprin:
+    - name: "has-replicas-field"
+      type: "FieldExists"
+      resource: "Deployment/my-app"
+      field: "spec.replicas"
+    - name: "has-selector"
+      type: "FieldExists"
+      resource: "Service/my-app"
+      field: "spec.selector"
 ```
 
 **Use Case:** Ensure required fields are present in rendered resources.
@@ -197,10 +216,11 @@ Validates that a field does not exist at a given path in a resource.
 **Example:**
 ```yaml
 assertions:
-  - name: "no-deprecated-field"
-    type: "FieldNotExists"
-    resource: "Deployment/my-app"
-    field: "spec.deprecated"
+  xprin:
+    - name: "no-deprecated-field"
+      type: "FieldNotExists"
+      resource: "Deployment/my-app"
+      field: "spec.deprecated"
 ```
 
 **Use Case:** Ensure deprecated or unwanted fields are not present in rendered resources.
@@ -226,18 +246,19 @@ Validates the value of a field in a resource using comparison operators.
 **Example:**
 ```yaml
 assertions:
-  - name: "replicas-equals-three"
-    type: "FieldValue"
-    resource: "Deployment/my-app"
-    field: "spec.replicas"
-    operator: "=="
-    value: 3
-  - name: "engine-is-postgresql"
-    type: "FieldValue"
-    resource: "Cluster/my-db"
-    field: "spec.forProvider.engine"
-    operator: "is"
-    value: "postgresql"
+  xprin:
+    - name: "replicas-equals-three"
+      type: "FieldValue"
+      resource: "Deployment/my-app"
+      field: "spec.replicas"
+      operator: "=="
+      value: 3
+    - name: "engine-is-postgresql"
+      type: "FieldValue"
+      resource: "Cluster/my-db"
+      field: "spec.forProvider.engine"
+      operator: "is"
+      value: "postgresql"
 ```
 
 **Use Case:** Validate specific field values match expected values.
@@ -260,37 +281,38 @@ tests:
       crds:
         - /path/to/crds
     assertions:
-      # Count validation
-      - name: "renders-three-resources"
-        type: "Count"
-        value: 3
-      
-      # Resource existence
-      - name: "deployment-exists"
-        type: "Exists"
-        resource: "Deployment/my-app"
-      - name: "service-exists"
-        type: "Exists"
-        resource: "Service/my-app"
-      
-      # Field validation
-      - name: "deployment-replicas"
-        type: "FieldValue"
-        resource: "Deployment/my-app"
-        field: "spec.replicas"
-        operator: "=="
-        value: 3
-      
-      - name: "service-type"
-        type: "FieldType"
-        resource: "Service/my-app"
-        field: "spec.type"
-        value: "string"
-      
-      - name: "has-selector"
-        type: "FieldExists"
-        resource: "Service/my-app"
-        field: "spec.selector"
+      xprin:
+        # Count validation
+        - name: "renders-three-resources"
+          type: "Count"
+          value: 3
+
+        # Resource existence
+        - name: "deployment-exists"
+          type: "Exists"
+          resource: "Deployment/my-app"
+        - name: "service-exists"
+          type: "Exists"
+          resource: "Service/my-app"
+
+        # Field validation
+        - name: "deployment-replicas"
+          type: "FieldValue"
+          resource: "Deployment/my-app"
+          field: "spec.replicas"
+          operator: "=="
+          value: 3
+
+        - name: "service-type"
+          type: "FieldType"
+          resource: "Service/my-app"
+          field: "spec.type"
+          value: "string"
+
+        - name: "has-selector"
+          type: "FieldExists"
+          resource: "Service/my-app"
+          field: "spec.selector"
 ```
 
 ### Comprehensive Example
@@ -305,82 +327,83 @@ tests:
       crds:
         - /path/to/crds
     assertions:
-      # Count assertion
-      - name: "renders-three-resources"
-        type: "Count"
-        value: 3
-      
-      # Resource existence
-      - name: "deployment-exists"
-        type: "Exists"
-        resource: "Deployment/my-app"
-      - name: "service-exists"
-        type: "Exists"
-        resource: "Service/my-app"
-      
-      # Resource non-existence
-      - name: "no-old-deployment"
-        type: "NotExists"
-        resource: "Deployment/old-app"
-      - name: "no-pods"
-        type: "NotExists"
-        resource: "Pod"
-      
-      # Field existence
-      - name: "has-replicas-field"
-        type: "FieldExists"
-        resource: "Deployment/my-app"
-        field: "spec.replicas"
-      - name: "no-deprecated-field"
-        type: "FieldNotExists"
-        resource: "Deployment/my-app"
-        field: "spec.deprecated"
-      
-      # Field type validation (all supported types)
-      - name: "replicas-is-number"
-        type: "FieldType"
-        resource: "Deployment/my-app"
-        field: "spec.replicas"
-        value: "number"
-      - name: "name-is-string"
-        type: "FieldType"
-        resource: "Deployment/my-app"
-        field: "metadata.name"
-        value: "string"
-      - name: "labels-is-object"
-        type: "FieldType"
-        resource: "Deployment/my-app"
-        field: "metadata.labels"
-        value: "object"
-      - name: "ports-is-array"
-        type: "FieldType"
-        resource: "Service/my-app"
-        field: "spec.ports"
-        value: "array"
-      - name: "enabled-is-boolean"
-        type: "FieldType"
-        resource: "Deployment/my-app"
-        field: "spec.enabled"
-        value: "boolean"
-      - name: "optional-field-is-null"
-        type: "FieldType"
-        resource: "Deployment/my-app"
-        field: "spec.optionalField"
-        value: "null"
-      
-      # Field value validation
-      - name: "replicas-equals-three"
-        type: "FieldValue"
-        resource: "Deployment/my-app"
-        field: "spec.replicas"
-        operator: "=="
-        value: 3
-      - name: "engine-is-postgresql"
-        type: "FieldValue"
-        resource: "Cluster/my-db"
-        field: "spec.forProvider.engine"
-        operator: "is"
-        value: "postgresql"
+      xprin:
+        # Count assertion
+        - name: "renders-three-resources"
+          type: "Count"
+          value: 3
+
+        # Resource existence
+        - name: "deployment-exists"
+          type: "Exists"
+          resource: "Deployment/my-app"
+        - name: "service-exists"
+          type: "Exists"
+          resource: "Service/my-app"
+
+        # Resource non-existence
+        - name: "no-old-deployment"
+          type: "NotExists"
+          resource: "Deployment/old-app"
+        - name: "no-pods"
+          type: "NotExists"
+          resource: "Pod"
+
+        # Field existence
+        - name: "has-replicas-field"
+          type: "FieldExists"
+          resource: "Deployment/my-app"
+          field: "spec.replicas"
+        - name: "no-deprecated-field"
+          type: "FieldNotExists"
+          resource: "Deployment/my-app"
+          field: "spec.deprecated"
+
+        # Field type validation (all supported types)
+        - name: "replicas-is-number"
+          type: "FieldType"
+          resource: "Deployment/my-app"
+          field: "spec.replicas"
+          value: "number"
+        - name: "name-is-string"
+          type: "FieldType"
+          resource: "Deployment/my-app"
+          field: "metadata.name"
+          value: "string"
+        - name: "labels-is-object"
+          type: "FieldType"
+          resource: "Deployment/my-app"
+          field: "metadata.labels"
+          value: "object"
+        - name: "ports-is-array"
+          type: "FieldType"
+          resource: "Service/my-app"
+          field: "spec.ports"
+          value: "array"
+        - name: "enabled-is-boolean"
+          type: "FieldType"
+          resource: "Deployment/my-app"
+          field: "spec.enabled"
+          value: "boolean"
+        - name: "optional-field-is-null"
+          type: "FieldType"
+          resource: "Deployment/my-app"
+          field: "spec.optionalField"
+          value: "null"
+
+        # Field value validation
+        - name: "replicas-equals-three"
+          type: "FieldValue"
+          resource: "Deployment/my-app"
+          field: "spec.replicas"
+          operator: "=="
+          value: 3
+        - name: "engine-is-postgresql"
+          type: "FieldValue"
+          resource: "Cluster/my-db"
+          field: "spec.forProvider.engine"
+          operator: "is"
+          value: "postgresql"
 ```
 
 ## Common vs Test-Level Assertions
@@ -397,12 +420,13 @@ Assertions can be defined in both the `common` section and at the test case leve
 ```yaml
 common:
   assertions:
-    - name: "common-count"
-      type: "Count"
-      value: 3
-    - name: "common-exists"
-      type: "Exists"
-      resource: "Deployment/my-app"
+    xprin:
+      - name: "common-count"
+        type: "Count"
+        value: 3
+      - name: "common-exists"
+        type: "Exists"
+        resource: "Deployment/my-app"
 
 tests:
   - name: "Test 1"
@@ -411,7 +435,7 @@ tests:
       xr: xr1.yaml
       composition: comp.yaml
       functions: /path/to/functions
-  
+
   - name: "Test 2"
     # Test case assertions replace common assertions
     inputs:
@@ -419,9 +443,10 @@ tests:
       composition: comp.yaml
       functions: /path/to/functions
     assertions:
-      - name: "test2-count"
-        type: "Count"
-        value: 5
+      xprin:
+        - name: "test2-count"
+          type: "Count"
+          value: 5
 ```
 
 For detailed information about merging logic, see [How It Works](how-it-works.md#common-vs-test-level-configuration).

--- a/docs/testsuite-specification.md
+++ b/docs/testsuite-specification.md
@@ -39,9 +39,10 @@ common:
       - name: "validate common outputs"
         run: "echo 'Validating {{ .Outputs.XR }}'"
   assertions:
-    - name: "common-resource-count"
-      type: "Count"
-      value: 3
+    xprin:
+      - name: "common-resource-count"
+        type: "Count"
+        value: 3
 
 tests:
 - name: "My Test Case"
@@ -74,18 +75,19 @@ tests:
       - name: "check render count"
         run: "echo 'Rendered {{ .Outputs.RenderCount }} resources'"
   assertions:
-    - name: "resource-count"
-      type: "Count"
-      value: 3
-    - name: "deployment-exists"
-      type: "Exists"
-      resource: "Deployment/my-app"
-    - name: "replicas-value"
-      type: "FieldValue"
-      resource: "Deployment/my-app"
-      field: "spec.replicas"
-      operator: "=="
-      value: 3
+    xprin:
+      - name: "resource-count"
+        type: "Count"
+        value: 3
+      - name: "deployment-exists"
+        type: "Exists"
+        resource: "Deployment/my-app"
+      - name: "replicas-value"
+        type: "FieldValue"
+        resource: "Deployment/my-app"
+        field: "spec.replicas"
+        operator: "=="
+        value: 3
 - name: "Test: Basic Setup with Claim"
   id: "test-case-2"
   inputs:
@@ -117,7 +119,7 @@ tests:
 | `inputs` | ❌ | map | Common inputs for all test cases |
 | `patches` | ❌ | map | Common patches for all test cases |
 | `hooks` | ❌ | map | Common hooks for all test cases |
-| `assertions` | ❌ | list | Common assertions for all test cases |
+| `assertions` | ❌ | map | Common assertions for all test cases (see [Assertions](assertions.md)) |
 
 ### Test Case
 
@@ -128,7 +130,7 @@ tests:
 | `inputs` | ✅ | map | Inputs for the test case |
 | `patches` | ❌ | map | XR patching configuration |
 | `hooks` | ❌ | map | Hooks for the test case |
-| `assertions` | ❌ | list | Assertions to validate rendered resources |
+| `assertions` | ❌ | map | Assertions to validate rendered resources (see [Assertions](assertions.md)) |
 
 ### Inputs
 

--- a/examples/mytests/6_assertions/example1_assertions_xprin.yaml
+++ b/examples/mytests/6_assertions/example1_assertions_xprin.yaml
@@ -17,86 +17,87 @@ tests:
     - run: echo "Running post-test hook"
 
   assertions:
-    # Count assertion
-    - name: "Number of resources"
-      type: "Count"
-      value: 3
+    xprin:
+      # Count assertion
+      - name: "Number of resources"
+        type: "Count"
+        value: 3
 
-    # Exists assertions
-    - name: "SecurityGroup should exist"
-      type: "Exists"
-      resource: "SecurityGroup/platform-aws-sg"
-    - name: "RDS should exist"
-      type: "Exists"
-      resource: "Cluster/platform-aws-rds"
+      # Exists assertions
+      - name: "SecurityGroup should exist"
+        type: "Exists"
+        resource: "SecurityGroup/platform-aws-sg"
+      - name: "RDS should exist"
+        type: "Exists"
+        resource: "Cluster/platform-aws-rds"
 
-    # NotExists assertions
-    - name: "EC2 should not exist"
-      type: "NotExists"
-      resource: "EC2/platform-aws-ec2"
-    - name: "No EC2 instances should exist"
-      type: "NotExists"
-      resource: "EC2"
+      # NotExists assertions
+      - name: "EC2 should not exist"
+        type: "NotExists"
+        resource: "EC2/platform-aws-ec2"
+      - name: "No EC2 instances should exist"
+        type: "NotExists"
+        resource: "EC2"
 
-    # FieldExists assertion
-    - name: "SecurityGroup should have a name"
-      type: "FieldExists"
-      resource: "SecurityGroup/platform-aws-sg"
-      field: "metadata.name"
+      # FieldExists assertion
+      - name: "SecurityGroup should have a name"
+        type: "FieldExists"
+        resource: "SecurityGroup/platform-aws-sg"
+        field: "metadata.name"
 
-    # FieldNotExists assertion
-    - name: "RDS should not have deprecated field"
-      type: "FieldNotExists"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.deprecatedField"
+      # FieldNotExists assertion
+      - name: "RDS should not have deprecated field"
+        type: "FieldNotExists"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.deprecatedField"
 
-    # FieldType assertions - all supported types
-    - name: "SecurityGroup description should be string"
-      type: "FieldType"
-      resource: "SecurityGroup/platform-aws-sg"
-      field: "spec.forProvider.description"
-      value: "string"
+      # FieldType assertions - all supported types
+      - name: "SecurityGroup description should be string"
+        type: "FieldType"
+        resource: "SecurityGroup/platform-aws-sg"
+        field: "spec.forProvider.description"
+        value: "string"
 
-    - name: "RDS backupRetentionPeriod should be number"
-      type: "FieldType"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.backupRetentionPeriod"
-      value: "number"
+      - name: "RDS backupRetentionPeriod should be number"
+        type: "FieldType"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.backupRetentionPeriod"
+        value: "number"
 
-    - name: "RDS vpcSecurityGroupIds should be array"
-      type: "FieldType"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.vpcSecurityGroupIds"
-      value: "array"
+      - name: "RDS vpcSecurityGroupIds should be array"
+        type: "FieldType"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.vpcSecurityGroupIds"
+        value: "array"
 
-    - name: "SecurityGroup metadata labels should be object"
-      type: "FieldType"
-      resource: "SecurityGroup/platform-aws-sg"
-      field: "metadata.labels"
-      value: "object"
+      - name: "SecurityGroup metadata labels should be object"
+        type: "FieldType"
+        resource: "SecurityGroup/platform-aws-sg"
+        field: "metadata.labels"
+        value: "object"
 
-    - name: "RDS masterPasswordSecretRef should be object"
-      type: "FieldType"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.masterPasswordSecretRef"
-      value: "object"
+      - name: "RDS masterPasswordSecretRef should be object"
+        type: "FieldType"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.masterPasswordSecretRef"
+        value: "object"
 
-    - name: "RDS finalSnapshotIdentifier should not exist"
-      type: "FieldNotExists"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.finalSnapshotIdentifier"
+      - name: "RDS finalSnapshotIdentifier should not exist"
+        type: "FieldNotExists"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.finalSnapshotIdentifier"
 
-    # FieldValue assertions
-    - name: "RDS should be Aurora PostgreSQL"
-      type: "FieldValue"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.engine"
-      operator: "is"
-      value: "aurora-postgresql"
+      # FieldValue assertions
+      - name: "RDS should be Aurora PostgreSQL"
+        type: "FieldValue"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.engine"
+        operator: "is"
+        value: "aurora-postgresql"
 
-    - name: "RDS backupRetentionPeriod should equal 1"
-      type: "FieldValue"
-      resource: "Cluster/platform-aws-rds"
-      field: "spec.forProvider.backupRetentionPeriod"
-      operator: "=="
-      value: 1
+      - name: "RDS backupRetentionPeriod should equal 1"
+        type: "FieldValue"
+        resource: "Cluster/platform-aws-rds"
+        field: "spec.forProvider.backupRetentionPeriod"
+        operator: "=="
+        value: 1

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -59,22 +59,27 @@ type Assertion struct {
 	Value    interface{} `yaml:"value"`    // Expected value for the assertion
 }
 
+// Assertions represents assertions grouped by execution engine.
+type Assertions struct {
+	Xprin []Assertion `yaml:"xprin,omitempty"` // xprin assertions (in-process)
+}
+
 // Common represents the common configuration for a testsuite file.
 type Common struct {
-	Inputs     Inputs      `yaml:"inputs"`
-	Patches    Patches     `yaml:"patches,omitempty"`
-	Hooks      Hooks       `yaml:"hooks,omitempty"`
-	Assertions []Assertion `yaml:"assertions,omitempty"`
+	Inputs     Inputs     `yaml:"inputs"`
+	Patches    Patches    `yaml:"patches,omitempty"`
+	Hooks      Hooks      `yaml:"hooks,omitempty"`
+	Assertions Assertions `yaml:"assertions,omitempty"`
 }
 
 // TestCase represents a single test case.
 type TestCase struct {
-	Name       string      `yaml:"name"`                 // Mandatory descriptive name
-	ID         string      `yaml:"id,omitempty"`         // Optional unique identifier
-	Inputs     Inputs      `yaml:"inputs"`               // Inputs of a test case
-	Patches    Patches     `yaml:"patches,omitempty"`    // Optional XR patching configuration
-	Hooks      Hooks       `yaml:"hooks,omitempty"`      // Optional execution hooks configuration
-	Assertions []Assertion `yaml:"assertions,omitempty"` // Optional assertions
+	Name       string     `yaml:"name"`                 // Mandatory descriptive name
+	ID         string     `yaml:"id,omitempty"`         // Optional unique identifier
+	Inputs     Inputs     `yaml:"inputs"`               // Inputs of a test case
+	Patches    Patches    `yaml:"patches,omitempty"`    // Optional XR patching configuration
+	Hooks      Hooks      `yaml:"hooks,omitempty"`      // Optional execution hooks configuration
+	Assertions Assertions `yaml:"assertions,omitempty"` // Optional assertions
 }
 
 // Inputs represents the inputs for a test case or common configuration.
@@ -143,7 +148,7 @@ func (h *Hooks) HasHooks() bool {
 
 // HasAssertions returns true if any assertions are set.
 func (c *Common) HasAssertions() bool {
-	return len(c.Assertions) > 0
+	return len(c.Assertions.Xprin) > 0
 }
 
 // CheckValidTestSuiteFile checks:
@@ -266,7 +271,7 @@ func (tc *TestCase) HasHooks() bool {
 
 // HasAssertions returns true if any assertions are defined.
 func (tc *TestCase) HasAssertions() bool {
-	return len(tc.Assertions) > 0
+	return len(tc.Assertions.Xprin) > 0
 }
 
 // MergeCommon merges common inputs and patches into the test case.

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1113,9 +1113,11 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "common-composition.yaml",
 					Functions:   "common-functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "common-count", Type: "Count", Value: 3},
-					{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "common-count", Type: "Count", Value: 3},
+						{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+					},
 				},
 			},
 			expected: TestCase{
@@ -1125,9 +1127,11 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "composition.yaml",
 					Functions:   "functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "common-count", Type: "Count", Value: 3},
-					{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "common-count", Type: "Count", Value: 3},
+						{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+					},
 				},
 			},
 		},
@@ -1140,8 +1144,10 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "composition.yaml",
 					Functions:   "functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "test-count", Type: "Count", Value: 5},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-count", Type: "Count", Value: 5},
+					},
 				},
 			},
 			common: Common{
@@ -1149,9 +1155,11 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "common-composition.yaml",
 					Functions:   "common-functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "common-count", Type: "Count", Value: 3},
-					{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "common-count", Type: "Count", Value: 3},
+						{Name: "common-exists", Type: "Exists", Resource: "Deployment/my-app"},
+					},
 				},
 			},
 			expected: TestCase{
@@ -1161,8 +1169,10 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "composition.yaml",
 					Functions:   "functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "test-count", Type: "Count", Value: 5},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-count", Type: "Count", Value: 5},
+					},
 				},
 			},
 		},
@@ -1175,8 +1185,10 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "composition.yaml",
 					Functions:   "functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "test-count", Type: "Count", Value: 5},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-count", Type: "Count", Value: 5},
+					},
 				},
 			},
 			common: Common{
@@ -1192,8 +1204,10 @@ func TestTestCase_mergeCommon(t *testing.T) {
 					Composition: "composition.yaml",
 					Functions:   "functions.yaml",
 				},
-				Assertions: []Assertion{
-					{Name: "test-count", Type: "Count", Value: 5},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-count", Type: "Count", Value: 5},
+					},
 				},
 			},
 		},
@@ -1806,15 +1820,17 @@ func TestTestCase_hasAssertions(t *testing.T) {
 		{
 			name: "no assertions",
 			testCase: TestCase{
-				Assertions: []Assertion{},
+				Assertions: Assertions{Xprin: []Assertion{}},
 			},
 			expected: false,
 		},
 		{
 			name: "one assertion",
 			testCase: TestCase{
-				Assertions: []Assertion{
-					{Name: "test-assertion", Type: "Count", Value: 3},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-assertion", Type: "Count", Value: 3},
+					},
 				},
 			},
 			expected: true,
@@ -1822,9 +1838,11 @@ func TestTestCase_hasAssertions(t *testing.T) {
 		{
 			name: "multiple assertions",
 			testCase: TestCase{
-				Assertions: []Assertion{
-					{Name: "test-count", Type: "Count", Value: 3},
-					{Name: "test-exists", Type: "Exists", Resource: "Deployment/my-app"},
+				Assertions: Assertions{
+					Xprin: []Assertion{
+						{Name: "test-count", Type: "Count", Value: 3},
+						{Name: "test-exists", Type: "Exists", Resource: "Deployment/my-app"},
+					},
 				},
 			},
 			expected: true,

--- a/internal/testexecution/runner/runner.go
+++ b/internal/testexecution/runner/runner.go
@@ -660,13 +660,13 @@ func (r *Runner) runTestCase(testCase api.TestCase, testSuiteResult *engine.Test
 	// Execute assertions if any are defined (collect errors but don't fail immediately)
 	if testCase.HasAssertions() {
 		if r.Debug {
-			utils.DebugPrintf("Executing %d assertions for test case '%s'\n", len(testCase.Assertions), testCase.Name)
+			utils.DebugPrintf("Executing %d assertions for test case '%s'\n", len(testCase.Assertions.Xprin), testCase.Name)
 		}
 
 		assertionExecutor := newAssertionExecutor(r.fs, &result.Outputs, r.Debug)
 
 		// Store assertion results in test case result
-		result.AssertionsAllResults, result.AssertionsFailedResults = assertionExecutor.executeAssertions(testCase.Assertions)
+		result.AssertionsAllResults, result.AssertionsFailedResults = assertionExecutor.executeAssertions(testCase.Assertions.Xprin)
 
 		if len(result.AssertionsFailedResults) > 0 {
 			finalError = append(finalError, result.MarkAssertionsFailed().Error())


### PR DESCRIPTION
Refactor assertions structure to organize assertions by execution engine. Assertions are now nested under the `xprin` key within the `assertions` section, enabling future extensibility for additional assertion engines e.g., `chainsaw`.

Changes:
- Update all assertion examples in documentation to use `assertions.xprin:`
- Update example YAML file to reflect new structure
- Add "Structure" section to assertions.md explaining the new format
- Update testsuite-specification.md field type from `list` to `map`

BREAKING CHANGE: Assertions must now use `assertions.xprin: [...]` format instead of `assertions: [...]`.