### PR TITLE
Use observed XR when passed through observed-resources

### DIFF
--- a/internal/testexecution/runner/observed_xr.go
+++ b/internal/testexecution/runner/observed_xr.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/yaml"
+)
+
+func (r *Runner) copyXRInput(inputXR, observedResources string) (string, error) {
+	copiedXR, err := r.copyInput(inputXR, "xr")
+	if err != nil {
+		return "", err
+	}
+
+	if observedResources == "" {
+		return copiedXR, nil
+	}
+
+	xr, err := loadXRResource(r.fs, inputXR)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return copiedXR, nil
+		}
+
+		return "", err
+	}
+
+	observed, err := loadObservedResources(r.fs, observedResources)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return copiedXR, nil
+		}
+
+		return "", err
+	}
+
+	for _, candidate := range observed {
+		if !sameResource(candidate, xr) {
+			continue
+		}
+
+		out, err := yaml.Marshal(candidate.Object)
+		if err != nil {
+			return "", err
+		}
+
+		if err := afero.WriteFile(r.fs, copiedXR, out, 0o600); err != nil {
+			return "", err
+		}
+
+		return copiedXR, nil
+	}
+
+	return copiedXR, nil
+}
+
+func loadXRResource(fs afero.Fs, path string) (*unstructured.Unstructured, error) {
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, err
+	}
+
+	xr := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(data, xr); err != nil {
+		return nil, fmt.Errorf("failed to parse XR YAML: %w", err)
+	}
+
+	return xr, nil
+}
+
+func loadObservedResources(fs afero.Fs, path string) ([]*unstructured.Unstructured, error) {
+	info, err := fs.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.IsDir() {
+		files, err := afero.ReadDir(fs, path)
+		if err != nil {
+			return nil, err
+		}
+
+		var resources []*unstructured.Unstructured
+		for _, file := range files {
+			if file.IsDir() {
+				continue
+			}
+			switch filepath.Ext(file.Name()) {
+			case ".yaml", ".yml":
+			default:
+				continue
+			}
+
+			docs, err := loadObservedResources(fs, filepath.Join(path, file.Name()))
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, docs...)
+		}
+
+		return resources, nil
+	}
+
+	data, err := afero.ReadFile(fs, path)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := k8syaml.NewYAMLToJSONDecoder(bytes.NewReader(data))
+	resources := make([]*unstructured.Unstructured, 0)
+
+	for {
+		resource := &unstructured.Unstructured{}
+		if err := decoder.Decode(resource); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			return nil, err
+		}
+		if resource.GetAPIVersion() == "" && resource.GetKind() == "" && resource.GetName() == "" {
+			continue
+		}
+
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+func sameResource(a, b *unstructured.Unstructured) bool {
+	return a.GetAPIVersion() == b.GetAPIVersion() &&
+		a.GetKind() == b.GetKind() &&
+		a.GetName() == b.GetName() &&
+		a.GetNamespace() == b.GetNamespace()
+}

--- a/internal/testexecution/runner/observed_xr_test.go
+++ b/internal/testexecution/runner/observed_xr_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/crossplane-contrib/xprin/internal/config"
+	testexecutionUtils "github.com/crossplane-contrib/xprin/internal/testexecution/utils"
+	cp "github.com/otiai10/copy"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require" //nolint:depguard // testify is widely used for testing
+)
+
+func TestCopyXRInputUsesMatchingObservedXR(t *testing.T) {
+	fs, r := newCopyXRInputTestRunner(t)
+
+	require.NoError(t, afero.WriteFile(fs, "/xr.yaml", []byte(`
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: original
+`), 0o600))
+	require.NoError(t, afero.WriteFile(fs, "/observed.yaml", []byte(`
+apiVersion: example.org/v1
+kind: Other
+metadata:
+  name: example
+---
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: observed
+status:
+  ready: true
+`), 0o600))
+
+	got, err := r.copyXRInput("/xr.yaml", "/observed.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "/inputs/xr/xr.yaml", got)
+
+	data, err := afero.ReadFile(fs, got)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "value: observed")
+	require.Contains(t, string(data), "ready: true")
+}
+
+func TestCopyXRInputUsesMatchingObservedXRFromDirectory(t *testing.T) {
+	fs, r := newCopyXRInputTestRunner(t)
+
+	require.NoError(t, afero.WriteFile(fs, "/xr.yaml", []byte(`
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: original
+`), 0o600))
+	require.NoError(t, fs.MkdirAll("/observed", 0o700))
+	require.NoError(t, afero.WriteFile(fs, "/observed/xr.yaml", []byte(`
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: observed
+status:
+  ready: true
+`), 0o600))
+	require.NoError(t, afero.WriteFile(fs, "/observed/ignored.txt", []byte(`
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: ignored
+`), 0o600))
+
+	got, err := r.copyXRInput("/xr.yaml", "/observed")
+	require.NoError(t, err)
+	require.Equal(t, "/inputs/xr/xr.yaml", got)
+
+	data, err := afero.ReadFile(fs, got)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "value: observed")
+	require.Contains(t, string(data), "ready: true")
+}
+
+func TestCopyXRInputKeepsOriginalXRWithoutObservedMatch(t *testing.T) {
+	fs, r := newCopyXRInputTestRunner(t)
+
+	require.NoError(t, afero.WriteFile(fs, "/xr.yaml", []byte(`
+apiVersion: example.org/v1
+kind: XExample
+metadata:
+  name: example
+spec:
+  value: original
+`), 0o600))
+	require.NoError(t, afero.WriteFile(fs, "/observed.yaml", []byte(`
+apiVersion: example.org/v1
+kind: Other
+metadata:
+  name: example
+spec:
+  value: observed
+`), 0o600))
+
+	got, err := r.copyXRInput("/xr.yaml", "/observed.yaml")
+	require.NoError(t, err)
+	require.Equal(t, "/inputs/xr/xr.yaml", got)
+
+	data, err := afero.ReadFile(fs, got)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "value: original")
+	require.NotContains(t, string(data), "value: observed")
+}
+
+func newCopyXRInputTestRunner(t *testing.T) (afero.Fs, *Runner) {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	r := NewRunner(&testexecutionUtils.Options{
+		Dependencies: map[string]string{"crossplane": config.CrossplaneCmd},
+	}, testSuiteFile, nil)
+	r.fs = fs
+	r.inputsDir = "/inputs"
+	r.copy = func(src, dest string, _ ...cp.Options) error {
+		data, err := afero.ReadFile(fs, src)
+		if err != nil {
+			return err
+		}
+		if err := fs.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+
+		return afero.WriteFile(fs, dest, data, 0o644)
+	}
+
+	require.NoError(t, fs.MkdirAll("/inputs", 0o700))
+
+	return fs, r
+}

--- a/internal/testexecution/runner/runner.go
+++ b/internal/testexecution/runner/runner.go
@@ -418,7 +418,7 @@ func (r *Runner) runTestCase(testCase api.TestCase, testSuiteResult *engine.Test
 
 	// Copy all inputs to the temporary inputs directory
 	if testCase.HasXR() {
-		testCase.Inputs.XR, err = r.copyInput(testCase.Inputs.XR, "xr")
+		testCase.Inputs.XR, err = r.copyXRInput(testCase.Inputs.XR, testCase.Inputs.ObservedResources)
 		if err != nil {
 			return result.Fail(err)
 		}


### PR DESCRIPTION
Disclaimer: the code in this PR was generated with Codex

Currently the XR is always retrieved from `inputs.xr` path. That means if the `status` field changes and it is then passed back into `observed-resources`, those changes are ignored. Now the code checks if the XR is included in the passed `observed-resources` with the same `apiVersion,kind,name,namespace` and then uses that instead.